### PR TITLE
Fix Error with Latest antrun

### DIFF
--- a/jbpt-pm/pom.xml
+++ b/jbpt-pm/pom.xml
@@ -192,7 +192,7 @@
 							<id>copy</id>
 							<phase>package</phase>
 							<configuration>
-								<tasks>
+								<target>
 									<echo>ANT TASK - copying files....</echo>
 									<copy todir="${project.build.directory}/lola2" overwrite="true" flatten="true">
 										<fileset dir="${basedir}/lola2">
@@ -243,7 +243,7 @@
 											<include name="*.gz" />
 										</fileset>
 									</copy-->
-								</tasks>
+								</target>
 							</configuration>
 							<goals>
 								<goal>run</goal>


### PR DESCRIPTION
### Issue
When `mvn clean install` `jbpt-pm` with the latest antrun gives the following error.
```
You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site.
```

### Fix
Use `<target>` instead of `<tasks>`.
